### PR TITLE
add configuration for bioconductor dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,4 +39,5 @@ Imports:
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 6.1.1
+RoxygenNote: 7.0.2
+biocViews:


### PR DESCRIPTION
Note that a package with `biocViews:` will install bioconductor packages as dependencies (but cannot be submitted to CRAN). `devtools` has updated roxygen2 but this should still run on R (≥ 3.2).